### PR TITLE
Added setVersionOnly

### DIFF
--- a/kafka-config/src/main/java/io/aiven/commons/kafka/config/SinceInfo.java
+++ b/kafka-config/src/main/java/io/aiven/commons/kafka/config/SinceInfo.java
@@ -161,6 +161,15 @@ public final class SinceInfo {
 	}
 
 	/**
+	 * Sets the override to be just the version of this component.
+	 * 
+	 * @return this
+	 */
+	public SinceInfo setVersionOnly() {
+		override = new Data(null, null, baseData.version);
+		return this;
+	}
+	/**
 	 * Gets the parsed ArtifactVersion for this sinceInfo.
 	 * 
 	 * @return the parsed ArtifactVersion for this sinceInfo.


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Adds a method to SinceInfo that sets the display (override) to be just the version from the SinceInfo.  This simplifies the construction of the output for connector properties.

<!-- Provide the issue number below if it exists. -->


# Why this way
Fits into the SinceInfo model.

