### PR TITLE
add io.aiven.commons.strings.Version to process versions 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
   </distributionManagement>
 
   <properties>
+    <project-version>${project.version}</project-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>17</maven.compiler.source>

--- a/strings/pom.xml
+++ b/strings/pom.xml
@@ -22,14 +22,18 @@
   <parent>
     <groupId>io.aiven.commons</groupId>
     <artifactId>aiven-commons</artifactId>
-    <version>2</version>
+    <version>3-SNAPSHOT</version>
   </parent>
 
   <artifactId>strings</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <name>Aiven commons strings</name>
   <description>Utilities to manipulate strings</description>
-  <properties></properties>
+
+  <properties>
+    <project-version>${project.version}</project-version>
+    <testing.io.aiven.commons-aiven-commons-version-example>1.0.3-SNAPSHOT</testing.io.aiven.commons-aiven-commons-version-example>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -76,6 +80,22 @@
             </manifest>
           </archive>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.3.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>write-project-properties</goal>
+            </goals>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <outputFile>${project.build.testOutputDirectory}/${project.groupId}/testing.${artifactId}.properties</outputFile>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/strings/src/main/java/io/aiven/commons/strings/CasedString.java
+++ b/strings/src/main/java/io/aiven/commons/strings/CasedString.java
@@ -6,7 +6,7 @@ package io.aiven.commons.strings;
         you may not use this file except in compliance with the License.
         You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing,
         software distributed under the License is distributed on an

--- a/strings/src/main/java/io/aiven/commons/strings/Version.java
+++ b/strings/src/main/java/io/aiven/commons/strings/Version.java
@@ -5,13 +5,15 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ *        SPDX-License-Identifier: Apache-2
  */
 
 package io.aiven.commons.strings;
@@ -19,23 +21,21 @@ package io.aiven.commons.strings;
 import java.io.InputStream;
 import java.util.Properties;
 
-
-
 /**
- * Reads a list of versions from a configuration file.
- * Versions may be retrieved by calling {@link #of(String)}.
- * By default, reads versions from "app.properties"
- * <p>
- *     Recommended usage is to add a package version property in the pom.xml that looks something like
- *     <pre>{@code
+ * Reads a list of versions from a configuration file. Versions may be retrieved
+ * by calling {@link #of(String)}. By default, reads versions from
+ * "app.properties" Recommended usage is to add a package version property in
+ * the pom.xml that looks something like
+ * 
+ * <pre>{@code
  *          <properties>
  *              <my-groupid-and-artifactid-version>1.3.4</my-groupid-and-artifactid-version>
  *          </properties>
  *     }</pre>
  *
- *     use the {@code properties-maven-plugin} to generate the properties file.
+ * use the {@code properties-maven-plugin} to generate the properties file.
  *
- *     <pre>{@code
+ * <pre>{@code
  *     <plugin>
  *         <groupId>org.codehaus.mojo</groupId>
  *         <artifactId>properties-maven-plugin</artifactId>
@@ -54,51 +54,62 @@ import java.util.Properties;
  *       </plugin>
  *     }</pre>
  *
- *    and then retrieve the code in the project as
+ * and then retrieve the code in the project as
  *
- *  <pre>{@code
- *      public static String VERSION = new Version("groupid/artifactid.properties").of("my-groupid-and-artifactid-version");
- *  }</pre>
+ * <pre>{@code
+ * public static String VERSION = new Version("groupid/artifactid.properties").of("my-groupid-and-artifactid-version");
+ * }</pre>
  *
- *    If additional values from the properties are desired then creating an instance of {@code Version} and calling
- *    {@link #of(String)} for the desired properties will work.
- * </p>
+ * If additional values from the properties are desired then creating an
+ * instance of {@code Version} and calling {@link #of(String)} for the desired
+ * properties will work.
  */
 public final class Version {
-    private static final String PROPERTIES_FILENAME = "app.properties";
+	private static final String PROPERTIES_FILENAME = "app.properties";
+	/** The recommended property name for the project.version */
+	public static final String RECOMMENDED_PROPERTY = "project-version";
+	private final Properties versions;
+	private final String errorMsg;
 
-    private final Properties versions;
-    private final String errorMsg;
+	/**
+	 * Default constructor. Reads "app.properties"
+	 */
+	public Version() {
+		this(PROPERTIES_FILENAME);
+	}
 
+	/**
+	 * property loader. Reads properties from the specified file which must be in
+	 * the classpath.
+	 * 
+	 * @param propertyFileName
+	 *            the name of the property file to read
+	 */
+	public Version(String propertyFileName) {
+		versions = new Properties();
+		String errMsg = null;
+		try (InputStream resourceStream = Thread.currentThread().getContextClassLoader()
+				.getResourceAsStream(propertyFileName)) {
+			versions.load(resourceStream);
+		} catch (final Exception e) { // NOPMD AvoidCatchingGenericException
+			errMsg = String.format("Error while loading %s: %s", propertyFileName, e.getMessage());
+		} finally {
+			errorMsg = errMsg;
+		}
+	}
 
-    /**
-     * Default constructor.  Reads "app.properties"
-     */
-    public Version() {
-        this(PROPERTIES_FILENAME);
-    }
-
-    /**
-     * property loader.  Reads properties from the specified file which must be in the classpath.
-     * @param propertyFileName
-     */
-    public Version(String propertyFileName) {
-        versions = new Properties();
-        String errMsg = null;
-        try (InputStream resourceStream = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream(propertyFileName)) {
-            versions.load(resourceStream);
-        } catch (final Exception e) { // NOPMD AvoidCatchingGenericException
-            errMsg = String.format("Error while loading %s: %s", propertyFileName, e.getMessage());
-        } finally {
-            errorMsg = errMsg;
-        }
-    }
-
-    public String of(String property) {
-        if (errorMsg != null) {
-            return errorMsg;
-        }
-        return versions.getProperty(property, "unknown");
-    }
+	/**
+	 * Retrieve a string for the property as defined in the property file.
+	 * 
+	 * @param property
+	 *            the name of the property.
+	 * @return the property stirng, "unknown" if not set, or an error message if the
+	 *         file was not read.
+	 */
+	public String of(String property) {
+		if (errorMsg != null) {
+			return errorMsg;
+		}
+		return versions.getProperty(property, "unknown");
+	}
 }

--- a/strings/src/test/java/io/aiven/commons/strings/CasedStringTest.java
+++ b/strings/src/test/java/io/aiven/commons/strings/CasedStringTest.java
@@ -6,7 +6,7 @@ package io.aiven.commons.strings;
         you may not use this file except in compliance with the License.
         You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing,
         software distributed under the License is distributed on an

--- a/strings/src/test/java/io/aiven/commons/strings/VersionTest.java
+++ b/strings/src/test/java/io/aiven/commons/strings/VersionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aiven.commons.strings;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VersionTest {
+
+	@Test
+	void testHandCoded() {
+		Version version = new Version("myHandCoded.properties");
+		assertThat(version.of("loneliestNumber")).isEqualTo("1");
+		assertThat(version.of("asBasAsOne")).isEqualTo("2");
+	}
+
+	@Test
+	void testGenerated() {
+		Version version = new Version("io.aiven.commons/testing.strings.properties");
+		assertThat(version.of("testing.io.aiven.commons-aiven-commons-version-example")).isEqualTo("1.0.3-SNAPSHOT");
+		assertThat(version.of(Version.RECOMMENDED_PROPERTY)).isNotNull();
+	}
+
+	@Test
+	void testMissingFile() {
+		Version version = new Version("io.aiven.commons/missing.strings.properties");
+		assertThat(version.of("testing.io.aiven.commons-aiven-commons-version-example")).isEqualTo(
+				"Error while loading io.aiven.commons/missing.strings.properties: inStream parameter is null");
+		assertThat(version.of(Version.RECOMMENDED_PROPERTY)).isNotNull();
+	}
+}

--- a/strings/src/test/resources/myHandCoded.properties
+++ b/strings/src/test/resources/myHandCoded.properties
@@ -1,0 +1,4 @@
+# https://www.apache.org/licenses/LICENSE-2.0
+# SPDX-License-Identifier: Apache-2
+loneliestNumber=1
+asBasAsOne=2


### PR DESCRIPTION
add io.aiven.commons.strings.Version to process versions from properties files.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Provides a wrapper class to read properties files from the class path and return values.  The expected use case is described in the javadocs.


# Why this way
It works when a jar has not yet been created, unlike the VersionInfo in the system package.
